### PR TITLE
Fix Postgres transaction begin

### DIFF
--- a/orator/connections/postgres_connection.py
+++ b/orator/connections/postgres_connection.py
@@ -37,7 +37,8 @@ class PostgresConnection(Connection):
         return True
 
     def begin_transaction(self):
-        self._connection.autocommit = False
+        if not self._transactions:
+            self._connection.autocommit = False
 
         super(PostgresConnection, self).begin_transaction()
 


### PR DESCRIPTION
# Description

Currently, for each transaction that is created, the "autocommit" parameter is modified, causing a modification in the current session, which is not allowed by psycopg2.

This PR intends to modify this behaviour, adding a condition that not modifies the parameter if a transaction already had been opened previously.

More informations on: https://github.com/sdispater/orator/issues/180