### PR TITLE
fix: Add two more messages to error connections

### DIFF
--- a/orator/connections/connection.py
+++ b/orator/connections/connection.py
@@ -371,6 +371,8 @@ class Connection(ConnectionInterface):
             "error writing data to the connection",
             "connection timed out",
             "resource deadlock avoided",
+            "connection already closed",
+            "eof detected",
         ]:
             if s in message:
                 return True


### PR DESCRIPTION
Postgres has two possibilities of connection losses not mapped in the reconnect scenarios. We are adding these two other cases.